### PR TITLE
Add binary ops as instructions to the SCCL interpreter

### DIFF
--- a/src/collectives/all_to_all.cc
+++ b/src/collectives/all_to_all.cc
@@ -7,13 +7,14 @@
 #include "enqueue.h"
 #include "collectives.h"
 
-NCCL_API(ncclResult_t, ncclAllToAll, const void* sendbuff, void* recvbuff, size_t sendcount,
+NCCL_API(ncclResult_t, ncclAllToAll, const void* sendbuff, void* recvbuff, argBuffs_t argbuffs, size_t sendcount,
     ncclDataType_t datatype, ncclComm_t comm, cudaStream_t stream);
-ncclResult_t ncclAllToAll(const void* sendbuff, void* recvbuff, size_t sendcount,
+ncclResult_t ncclAllToAll(const void* sendbuff, void* recvbuff, argBuffs_t argbuffs, size_t sendcount,
     ncclDataType_t datatype, ncclComm_t comm, cudaStream_t stream) {
   NVTX3_FUNC_RANGE_IN(nccl_domain);
   struct ncclInfo info = { ncclFuncAllToAll, "AllToAll",
     sendbuff, recvbuff, sendcount, datatype, ncclSum, 0, comm, stream, /* Args */
     SCCL_CHUNKSTEPS, SCCL_SLICESTEPS };
+  info.argbuffs = argbuffs;
   return ncclEnqueueCheck(&info);
 }

--- a/src/collectives/device/all_to_all.cu
+++ b/src/collectives/device/all_to_all.cu
@@ -8,4 +8,4 @@
 #include "common.h"
 #include "collectives.h"
 
-IMPL_COLL_C(AllToAll);
+IMPL_COLL_R(AllToAll);

--- a/src/collectives/device/common_kernel.h
+++ b/src/collectives/device/common_kernel.h
@@ -305,12 +305,6 @@ __device__ __forceinline__ void ReduceCopy128bMulti(const int w, const int nw, c
   const int inc = nw * UNROLL * WARP_SIZE;
   int offset = w * UNROLL * WARP_SIZE + t;
 
-  if (w == 0 && t == 0 && offset == 0) {
-    printf("ReduceCopy128bMulti\n %d srcs %d dsts\n", nsrcs, ndsts);
-    printf("src[0] %f(%p), src[1] %f(%p), dst[0] %p\n",
-           *s[0], s[0], *s[1], s[1], d[0]);
-  }
-
   const Pack128* srcs[MAXSRCS];
   for (int i=0; i<MAXSRCS; i++) srcs[i] = ((const Pack128*)(s[i]+elemOffset))+offset;
   Pack128* dsts[MAXDSTS];
@@ -321,17 +315,11 @@ __device__ __forceinline__ void ReduceCopy128bMulti(const int w, const int nw, c
     // Load and reduce
     for (int u = 0; u < UNROLL; ++u) Fetch128(vals[u], srcs[0]+u*WARP_SIZE);
 
-    if (w == 0 && t == 0 && offset == 0) printf(
-        "0loaded %f from srcs[0]\n", *(float*)&(vals[0]));
     #pragma unroll
     for (int i=1; i<MINSRCS; i++) {
       Pack128 vals2[UNROLL];
       for (int u = 0; u < UNROLL; ++u) Fetch128(vals2[u], srcs[i]+u*WARP_SIZE);
       for (int u = 0; u < UNROLL; ++u) MULTI128<FUNC, T>()(vals[u], vals2[u]);
-      if (w == 0 && t == 0 && offset == 0)
-        printf("1loaded %f from srcs[%d]\n", *(float *)&(vals2[0]), i);
-      if (w == 0 && t == 0 && offset == 0)
-        printf("1computed %f\n", *(float *)&(vals[0]));
     }
     #pragma unroll
     for (int i=MINSRCS; i<MAXSRCS; i++) {
@@ -339,10 +327,6 @@ __device__ __forceinline__ void ReduceCopy128bMulti(const int w, const int nw, c
         Pack128 vals2[UNROLL];
         for (int u = 0; u < UNROLL; ++u) Fetch128(vals2[u], srcs[i]+u*WARP_SIZE);
         for (int u = 0; u < UNROLL; ++u) MULTI128<FUNC, T>()(vals[u], vals2[u]);
-        if (w == 0 && t == 0 && offset == 0)
-          printf("2loaded %f\n", *(float *)&(vals2[0]));
-        if (w == 0 && t == 0 && offset == 0)
-          printf("2computed %f\n", *(float *)&(vals[0]));
       }
     }
 
@@ -375,12 +359,6 @@ __device__ __forceinline__ void ReduceOrCopyMulti(const int tid, const int nthre
   int Nrem = N;
   if (Nrem <= 0) return;
 
-  if (tid == 0) {
-    printf("ReduceOrCopyMulti %d srcs %d dsts\n", nsrcs, ndsts);
-    printf("src[0] %f(%p), src[1] %f(%p), dst[0] %p\n",
-           *srcs[0], srcs[0], *srcs[1], srcs[1], dsts[0]);
-  }
-
   int w = tid / WARP_SIZE;       // Warp number
   int nw = nthreads / WARP_SIZE; // Number of warps
   int t = tid % WARP_SIZE;       // Thread (inside the warp)
@@ -399,8 +377,6 @@ __device__ __forceinline__ void ReduceOrCopyMulti(const int tid, const int nthre
     // fast path: use 128b loads/stores to do the bulk of the work,
     // assuming the pointers we have are all 128-bit aligned.
 
-    if (tid == 0) printf("fast path main loop\n");
-
     // main loop
     int Npack = (Nrem / (PACKELEMS*UNROLL*WARP_SIZE)) * (UNROLL*WARP_SIZE); // round down
     int Nelem = Npack * PACKELEMS;
@@ -410,8 +386,6 @@ __device__ __forceinline__ void ReduceOrCopyMulti(const int tid, const int nthre
     Nrem -= Nelem;
     if (Nrem == 0) return;
     offset += Nelem;
-
-    if (tid == 0) printf("non-unrolled fast path main loop\n");
 
     // slightly less optimized for section when we don't have full unrolling
     Npack = Nrem / PACKELEMS;
@@ -424,8 +398,6 @@ __device__ __forceinline__ void ReduceOrCopyMulti(const int tid, const int nthre
     offset += Nelem;
   }
 
-  if (tid == 0) printf("unrolled non-aligned buffers\n");
-
   // unrolled, by-type (mostly for unaligned buffers)
   int Nelem = (Nrem / (UNROLL*PACKELEMS/2*WARP_SIZE)) * (UNROLL*PACKELEMS/2*WARP_SIZE); // round down
 
@@ -434,8 +406,6 @@ __device__ __forceinline__ void ReduceOrCopyMulti(const int tid, const int nthre
   Nrem -= Nelem;
   if (Nrem == 0) return;
   offset += Nelem;
-
-  if (tid == 0) printf("non-unrolled non-aligned buffers\n");
 
   // no unroll, by type. Should finish what's remaining.
   ReduceCopyMulti<FUNC, T, 1, MINSRCS, MAXSRCS, MINDSTS, MAXDSTS>(w, nw, t, nsrcs, srcs, ndsts, dsts, offset, Nrem);

--- a/src/collectives/device/common_kernel.h
+++ b/src/collectives/device/common_kernel.h
@@ -257,6 +257,8 @@ __device__ __forceinline__ void ReduceCopyMulti(const int w, const int nw, const
   const int inc = nw * UNROLL * WARP_SIZE;
   int offset = w * UNROLL * WARP_SIZE + t;
 
+  //printf("ReduceCopyMulti: for non-aligned buffers: this never happens?\n");
+
   const T* srcs[MAXSRCS];
   for (int i=0; i<MAXSRCS; i++) srcs[i] = s[i]+elemOffset+offset;
   T* dsts[MAXDSTS];
@@ -302,24 +304,57 @@ __device__ __forceinline__ void ReduceCopyMulti(const int w, const int nw, const
 template<class FUNC, typename T, int UNROLL, int MINSRCS, int MAXSRCS, int MINDSTS, int MAXDSTS>
 __device__ __forceinline__ void ReduceCopy128bMulti(const int w, const int nw, const int t,
     int nsrcs, const T** s, int ndsts, T** d, const int elemOffset, const int Npack) {
+  static_assert(MINSRCS <= MAXSRCS, "");
+  static_assert(MINDSTS <= MAXDSTS, "");
   const int inc = nw * UNROLL * WARP_SIZE;
   int offset = w * UNROLL * WARP_SIZE + t;
+
+  //if (w == 0 && t == 0 && offset == 0) {
+  //  printf("1ReduceCopy128bMulti\n %d srcs %d dsts, elemOffset %d\n", nsrcs, ndsts, elemOffset);
+  //  printf("1UNROLL %d, MINSRCS %d, MAXSRCS %d, MINDSTS %d, MAXDSTS %d\n",
+  //         UNROLL, MINSRCS, MAXSRCS, MINDSTS, MAXDSTS);
+  //  printf("1src[0] %f(%p), src[1] %f(%p), dst[0] %p\n",
+  //         *(float*)s[0], s[0], *(float*)s[1], s[1], d[0]);
+  //}
 
   const Pack128* srcs[MAXSRCS];
   for (int i=0; i<MAXSRCS; i++) srcs[i] = ((const Pack128*)(s[i]+elemOffset))+offset;
   Pack128* dsts[MAXDSTS];
   for (int i=0; i<MAXDSTS; i++) dsts[i] = ((Pack128*)(d[i]+elemOffset))+offset;
 
+  //if (w == 0 && t == 0 && offset == 0) {
+  //  printf("2ReduceCopy128bMulti\n %d srcs %d dsts\n", nsrcs, ndsts);
+  //  printf("2UNROLL %d, MINSRCS %d, MAXSRCS %d, MINDSTS %d, MAXDSTS %d\n",
+  //         UNROLL, MINSRCS, MAXSRCS, MINDSTS, MAXDSTS);
+  //  printf("2src[0] %f(%p), src[1] %f(%p), dst[0] %p\n",
+  //         *(float*)srcs[0], srcs[0], *(float*)srcs[1], srcs[1], dsts[0]);
+  //}
+
   while (offset < Npack) {
     Pack128 vals[UNROLL];
     // Load and reduce
     for (int u = 0; u < UNROLL; ++u) Fetch128(vals[u], srcs[0]+u*WARP_SIZE);
 
+    //if (w == 0 && t == 0 && offset == 0)
+    //if (((long long)srcs[0] & 0xff) == 0)
+    //  printf("0loaded %f from srcs[0] %p \n", *(float*)&(vals[0]), srcs[0]);
     #pragma unroll
     for (int i=1; i<MINSRCS; i++) {
       Pack128 vals2[UNROLL];
       for (int u = 0; u < UNROLL; ++u) Fetch128(vals2[u], srcs[i]+u*WARP_SIZE);
       for (int u = 0; u < UNROLL; ++u) MULTI128<FUNC, T>()(vals[u], vals2[u]);
+      //if (w == 0 && t == 0 && offset == 0)
+      //if (((long long)srcs[i] & 0xff) == 0)
+      //  printf("1loaded %f from srcs[%d] %p \n"
+      //         "1computed %f\n"
+      //         "1s[0] %f(%p), s[1] %f(%p), d[0] %p\n"
+      //         "1src[0] %f(%p), src[1] %f(%p), dst[0] %p\n"
+      //         "1w %d, nw %d, t %d, elemOffset %d, offset %d, Npack %d\n",
+      //      *(float *)&(vals2[0]), i, srcs[i],
+      //      *(float *)&(vals[0]),
+      //     *(float*)s[0], s[0], *(float*)s[1], s[1], d[0],
+      //     *(float*)srcs[0], srcs[0], *(float*)srcs[1], srcs[1], dsts[0],
+      //     w, nw, t, elemOffset, offset, Npack);
     }
     #pragma unroll
     for (int i=MINSRCS; i<MAXSRCS; i++) {
@@ -327,6 +362,10 @@ __device__ __forceinline__ void ReduceCopy128bMulti(const int w, const int nw, c
         Pack128 vals2[UNROLL];
         for (int u = 0; u < UNROLL; ++u) Fetch128(vals2[u], srcs[i]+u*WARP_SIZE);
         for (int u = 0; u < UNROLL; ++u) MULTI128<FUNC, T>()(vals[u], vals2[u]);
+        //if (w == 0 && t == 0 && offset == 0)
+        //  printf("2loaded %f\n", *(float *)&(vals2[0]));
+        //if (w == 0 && t == 0 && offset == 0)
+        //  printf("2computed %f\n", *(float *)&(vals[0]));
       }
     }
 
@@ -334,11 +373,17 @@ __device__ __forceinline__ void ReduceCopy128bMulti(const int w, const int nw, c
     #pragma unroll
     for (int i = 0; i < MINDSTS; i++) {
       for (int u = 0; u < UNROLL; ++u) Store128(dsts[i]+u*WARP_SIZE, vals[u]);
+      //if (w == 0 && t == 0 && offset == 0)
+      //if ((long long)dsts[i] & 0xFF == 0)
+      //if (((long long)dsts[i] & 0xff) == 0)
+      //  printf("3stored %f to %p\n", *(float *)&(vals[0]), dsts[i]);
     }
     #pragma unroll
     for (int i=MINDSTS; i<MAXDSTS; i++) {
       if (i<ndsts) {
         for (int u = 0; u < UNROLL; ++u) Store128(dsts[i]+u*WARP_SIZE, vals[u]);
+        //if (w == 0 && t == 0 && offset == 0)
+        //  printf("4stored %f to %p\n", *(float *)&(vals[0]), dsts[i]);
       }
     }
     for (int i=0; i<MAXSRCS; i++) srcs[i] += inc;
@@ -356,8 +401,17 @@ template<int UNROLL, class FUNC, typename T, int MINSRCS, int MAXSRCS, int MINDS
 __device__ __forceinline__ void ReduceOrCopyMulti(const int tid, const int nthreads,
     int nsrcs, const T** srcs, int ndsts, T** dsts,
     int N) {
+  static_assert(MINSRCS <= MAXSRCS, "");
+  static_assert(MINDSTS <= MAXDSTS, "");
   int Nrem = N;
   if (Nrem <= 0) return;
+  //if (tid == 0) {
+  //  printf("ReduceOrCopyMulti tid %d, %d srcs %d dsts\n", tid, nsrcs, ndsts);
+  //  printf("UNROLL %d, MINSRCS %d, MAXSRCS %d, MINDSTS %d, MAXDSTS %d\n",
+  //         UNROLL, MINSRCS, MAXSRCS, MINDSTS, MAXDSTS);
+  //  printf("src[0] %f(%p), src[1] %f(%p), dst[0] %p\n",
+  //         *(float*)srcs[0], srcs[0], *(float*)srcs[1], srcs[1], dsts[0]);
+  //}
 
   int w = tid / WARP_SIZE;       // Warp number
   int nw = nthreads / WARP_SIZE; // Number of warps
@@ -377,6 +431,7 @@ __device__ __forceinline__ void ReduceOrCopyMulti(const int tid, const int nthre
     // fast path: use 128b loads/stores to do the bulk of the work,
     // assuming the pointers we have are all 128-bit aligned.
 
+    //if (tid == 0) printf("fast path main loop\n");
     // main loop
     int Npack = (Nrem / (PACKELEMS*UNROLL*WARP_SIZE)) * (UNROLL*WARP_SIZE); // round down
     int Nelem = Npack * PACKELEMS;
@@ -387,6 +442,7 @@ __device__ __forceinline__ void ReduceOrCopyMulti(const int tid, const int nthre
     if (Nrem == 0) return;
     offset += Nelem;
 
+    //if (tid == 0) printf("non-unrolled fast path main loop\n");
     // slightly less optimized for section when we don't have full unrolling
     Npack = Nrem / PACKELEMS;
     Nelem = Npack * PACKELEMS;
@@ -398,6 +454,7 @@ __device__ __forceinline__ void ReduceOrCopyMulti(const int tid, const int nthre
     offset += Nelem;
   }
 
+  //if (tid == 0) printf("unrolled non-aligned buffers\n");
   // unrolled, by-type (mostly for unaligned buffers)
   int Nelem = (Nrem / (UNROLL*PACKELEMS/2*WARP_SIZE)) * (UNROLL*PACKELEMS/2*WARP_SIZE); // round down
 
@@ -407,6 +464,7 @@ __device__ __forceinline__ void ReduceOrCopyMulti(const int tid, const int nthre
   if (Nrem == 0) return;
   offset += Nelem;
 
+  //if (tid == 0) printf("non-unrolled non-aligned buffers\n");
   // no unroll, by type. Should finish what's remaining.
   ReduceCopyMulti<FUNC, T, 1, MINSRCS, MAXSRCS, MINDSTS, MAXDSTS>(w, nw, t, nsrcs, srcs, ndsts, dsts, offset, Nrem);
 }

--- a/src/collectives/device/common_kernel.h
+++ b/src/collectives/device/common_kernel.h
@@ -403,14 +403,19 @@ __device__ __forceinline__ void ReduceOrCopyMulti(const int tid, const int nthre
     int N) {
   static_assert(MINSRCS <= MAXSRCS, "");
   static_assert(MINDSTS <= MAXDSTS, "");
+  static_assert(MINSRCS >= 1, "");
   int Nrem = N;
   if (Nrem <= 0) return;
   //if (tid == 0) {
-  //  printf("ReduceOrCopyMulti tid %d, %d srcs %d dsts\n", tid, nsrcs, ndsts);
-  //  printf("UNROLL %d, MINSRCS %d, MAXSRCS %d, MINDSTS %d, MAXDSTS %d\n",
-  //         UNROLL, MINSRCS, MAXSRCS, MINDSTS, MAXDSTS);
-  //  printf("src[0] %f(%p), src[1] %f(%p), dst[0] %p\n",
-  //         *(float*)srcs[0], srcs[0], *(float*)srcs[1], srcs[1], dsts[0]);
+  //  printf("ReduceOrCopyMulti tid %d, %d srcs %d dsts\n"
+  //         "UNROLL %d, MINSRCS %d, MAXSRCS %d, MINDSTS %d, MAXDSTS %d\n"
+  //         "src[0] %f(%p), src[1] %f(%p), dst[0] %p\n",
+  //         tid, nsrcs, ndsts,
+  //         UNROLL, MINSRCS, MAXSRCS, MINDSTS, MAXDSTS,
+  //         *(float*)srcs[0], srcs[0],
+  //         (MINSRCS > 1) ? (*(float*)srcs[1]) : 0.0f,
+  //         (MINSRCS > 1) ? srcs[1] : nullptr,
+  //         MINDSTS ? dsts[0] : nullptr);
   //}
 
   int w = tid / WARP_SIZE;       // Warp number

--- a/src/collectives/device/functions.cu
+++ b/src/collectives/device/functions.cu
@@ -63,7 +63,7 @@ __device__ struct ncclShmemData* ncclShmem;
   NCCL_FUNCS2B(AllGather), \
   NCCL_FUNCS2A(ReduceScatter), \
   NCCL_FUNCS2A(AllReduce), \
-  NCCL_FUNCS2B(AllToAll) }
+  NCCL_FUNCS2A(AllToAll) }
 
 // Must be consistent with the ncclFuncSet enum
 __device__ ncclKern_t ncclFuncs[1+NCCL_NUM_FUNCTIONS*ncclNumOps*ncclNumTypes*NCCL_NUM_ALGORITHMS*NCCL_NUM_PROTOCOLS] = {
@@ -77,7 +77,7 @@ __device__ ncclKern_t ncclFuncs[1+NCCL_NUM_FUNCTIONS*ncclNumOps*ncclNumTypes*NCC
   NCCL_FUNCS2B(AllGather),
   NCCL_FUNCS2A(ReduceScatter),
   NCCL_FUNCS2A(AllReduce),
-  NCCL_FUNCS2B(AllToAll)
+  NCCL_FUNCS2A(AllToAll)
 #endif
 };
 

--- a/src/collectives/device/primitives.h
+++ b/src/collectives/device/primitives.h
@@ -135,9 +135,8 @@ class ncclPrimitives {
             /*For SCCL interpreter:*/ class BinaryOp=FUNC, typename Type=T, int SRC2=0>
   inline __device__ void
   GenericOp(const T* srcPtr, T* dstPtr, int nelem, ssize_t directOffset, const T* src2Ptr = nullptr) {
-    if (tid == 0)
-      printf("primitives GenericOp datatype size %lu, src %p, src2 %p, dst %p nelem %d\n",
-             sizeof(Type), srcPtr, src2Ptr, dstPtr, nelem);
+    //printf("primitives GenericOp datatype size %lu, src %p, src2 %p, dst %p nelem %d\n",
+    //       sizeof(Type), srcPtr, src2Ptr, dstPtr, nelem);
     int offset = 0;
     int sliceSize = stepSize*SLICESTEPS;
     int dataSize = max(DIVUP(nelem, 16*SLICESPERCHUNK)*16, sliceSize/32);

--- a/src/collectives/device/primitives.h
+++ b/src/collectives/device/primitives.h
@@ -159,7 +159,7 @@ class ncclPrimitives {
               ReduceOrCopyMulti<UNROLL, BinaryOp, Type, 1, 1, 1, (1-SEND)+NSEND>(tid, nworkers, 1, (const Type**)srcs, nsend, (Type**)dsts+1, realSize);
             }
           } else {
-            ReduceOrCopyMulti<UNROLL, BinaryOp, Type, RECV+SRC+SRC2, RECV*NRECV+SRC, SEND+DST, SEND*NSEND+DST>(tid, nworkers, RECV*nrecv+SRC+SRC2, (const Type**)srcs, SEND*nsend+DST, (Type**)dsts, realSize);
+            ReduceOrCopyMulti<UNROLL, BinaryOp, Type, RECV+SRC+SRC2, RECV*NRECV+SRC+SRC2, SEND+DST, SEND*NSEND+DST>(tid, nworkers, RECV*nrecv+SRC+SRC2, (const Type**)srcs, SEND*nsend+DST, (Type**)dsts, realSize);
           }
         }
       }

--- a/src/collectives/device/primitives.h
+++ b/src/collectives/device/primitives.h
@@ -135,8 +135,9 @@ class ncclPrimitives {
             /*For SCCL interpreter:*/ class BinaryOp=FUNC, typename Type=T, int SRC2=0>
   inline __device__ void
   GenericOp(const T* srcPtr, T* dstPtr, int nelem, ssize_t directOffset, const T* src2Ptr = nullptr) {
-    //printf("primitives GenericOp datatype size %lu, src %p, src2 %p, dst %p nelem %d\n",
-    //       sizeof(Type), srcPtr, src2Ptr, dstPtr, nelem);
+    if (tid == 0)
+      printf("primitives GenericOp datatype size %lu, src %p, src2 %p, dst %p nelem %d\n",
+             sizeof(Type), srcPtr, src2Ptr, dstPtr, nelem);
     int offset = 0;
     int sliceSize = stepSize*SLICESTEPS;
     int dataSize = max(DIVUP(nelem, 16*SLICESPERCHUNK)*16, sliceSize/32);

--- a/src/collectives/device/primitives.h
+++ b/src/collectives/device/primitives.h
@@ -317,35 +317,10 @@ class ncclPrimitives {
     GenericOp<0, 1, 1, 1, 1, 1>(src, dst, nelem, directOffset);
   }
 
+  template <class BinaryOp>
   __device__ __forceinline__ void
-  add(const T* src, T* dst, int nelem) {
-    GenericOp<0, 0, 0, 0, 1, 1, FuncSum<T>>(src, dst, nelem, 0);
-  }
-
-  __device__ __forceinline__ void
-  sub(const T* src, T* dst, int nelem) {
-    GenericOp<0, 0, 0, 0, 1, 1, FuncDiff<T>>(src, dst, nelem, 0);
-  }
-
-  __device__ __forceinline__ void
-  mul(const T* src, T* dst, int nelem) {
-    GenericOp<0, 0, 0, 0, 1, 1, FuncProd<T>>(src, dst, nelem, 0);
-  }
-
-  // Note this method cannot be named "min" due to a name conflict
-  __device__ __forceinline__ void
-  minimum(const T* src, T* dst, int nelem) {
-    GenericOp<0, 0, 0, 0, 1, 1, FuncMin<T>>(src, dst, nelem, 0);
-  }
-
-  __device__ __forceinline__ void
-  maximum(const T* src, T* dst, int nelem) {
-    GenericOp<0, 0, 0, 0, 1, 1, FuncMax<T>>(src, dst, nelem, 0);
-  }
-
-  __device__ __forceinline__ void
-  invsqrt(const T* src, T* dst, int nelem) {
-    GenericOp<0, 0, 0, 0, 1, 1, FuncInvSqrt<T>>(src, dst, nelem, 0);
+  binaryOp(const T* src, T* dst, int nelem) {
+    GenericOp<0, 0, 0, 0, 1, 1, BinaryOp>(src, dst, nelem, 0);
   }
 
   __device__ __forceinline__ ~ncclPrimitives() {

--- a/src/collectives/device/primitives.h
+++ b/src/collectives/device/primitives.h
@@ -343,6 +343,11 @@ class ncclPrimitives {
     GenericOp<0, 0, 0, 0, 1, 1, FuncMax<T>>(src, dst, nelem, 0);
   }
 
+  __device__ __forceinline__ void
+  invsqrt(const T* src, T* dst, int nelem) {
+    GenericOp<0, 0, 0, 0, 1, 1, FuncInvSqrt<T>>(src, dst, nelem, 0);
+  }
+
   __device__ __forceinline__ ~ncclPrimitives() {
     // Save steps for the next operation
     saveSync();

--- a/src/collectives/device/primitives.h
+++ b/src/collectives/device/primitives.h
@@ -135,8 +135,9 @@ class ncclPrimitives {
             /*For SCCL interpreter:*/ class BinaryOp=FUNC, typename Type=T, int SRC2=0>
   inline __device__ void
   GenericOp(const T* srcPtr, T* dstPtr, int nelem, ssize_t directOffset, const T* src2Ptr = nullptr) {
-    //printf("primitives GenericOp datatype size %lu, src %p, src2 %p, dst %p nelem %d\n",
-    //       sizeof(Type), srcPtr, src2Ptr, dstPtr, nelem);
+    //if (tid == 0)
+    //  printf("primitives GenericOp datatype size %lu, src %p, src2 %p, dst %p nelem %d, nworkers %d\n",
+    //         sizeof(Type), srcPtr, src2Ptr, dstPtr, nelem, nworkers);
     int offset = 0;
     int sliceSize = stepSize*SLICESTEPS;
     int dataSize = max(DIVUP(nelem, 16*SLICESPERCHUNK)*16, sliceSize/32);

--- a/src/collectives/device/primitives.h
+++ b/src/collectives/device/primitives.h
@@ -317,6 +317,11 @@ class ncclPrimitives {
     GenericOp<0, 1, 1, 1, 1, 1>(src, dst, nelem, directOffset);
   }
 
+  __device__ __forceinline__ void
+  binaryOp(const T* src, T* dst, int nelem) {
+    GenericOp<0, 0, 0, 0, 1, 1>(src, dst, nelem, 0);
+  }
+
   __device__ __forceinline__ ~ncclPrimitives() {
     // Save steps for the next operation
     saveSync();

--- a/src/collectives/device/prims_ll.h
+++ b/src/collectives/device/prims_ll.h
@@ -237,6 +237,10 @@ class ncclLLPrimitives {
     return LLGenericOp<1, 1, 1, 1>(src, dst, nelem);
   }
 
+  __device__ void binaryOp(const T* src, T* dst, int nelem) {
+    return LLGenericOp<0, 0, 1, 1>(src, dst, nelem);
+  }
+
   __device__ __forceinline__ ~ncclLLPrimitives() {
     // Save steps for the next operation
     saveRecvSync();

--- a/src/collectives/device/prims_ll.h
+++ b/src/collectives/device/prims_ll.h
@@ -237,28 +237,9 @@ class ncclLLPrimitives {
     return LLGenericOp<1, 1, 1, 1>(src, dst, nelem);
   }
 
-  __device__ void add(const T* src, T* dst, int nelem) {
-    return LLGenericOp<0, 0, 1, 1, FuncSum<T>>(src, dst, nelem);
-  }
-
-  __device__ void sub(const T* src, T* dst, int nelem) {
-    return LLGenericOp<0, 0, 1, 1, FuncDiff<T>>(src, dst, nelem);
-  }
-
-  __device__ void mul(const T* src, T* dst, int nelem) {
-    return LLGenericOp<0, 0, 1, 1, FuncProd<T>>(src, dst, nelem);
-  }
-
-  __device__ void minimum(const T* src, T* dst, int nelem) {
-    return LLGenericOp<0, 0, 1, 1, FuncMin<T>>(src, dst, nelem);
-  }
-
-  __device__ void maximum(const T* src, T* dst, int nelem) {
-    return LLGenericOp<0, 0, 1, 1, FuncMax<T>>(src, dst, nelem);
-  }
-
-  __device__ void invsqrt(const T* src, T* dst, int nelem) {
-    return LLGenericOp<0, 0, 1, 1, FuncInvSqrt<T>>(src, dst, nelem);
+  template <class BinaryOp>
+  __device__ void binaryOp(const T* src, T* dst, int nelem) {
+    return LLGenericOp<0, 0, 1, 1, BinaryOp>(src, dst, nelem);
   }
 
   __device__ __forceinline__ ~ncclLLPrimitives() {

--- a/src/collectives/device/prims_ll.h
+++ b/src/collectives/device/prims_ll.h
@@ -257,6 +257,10 @@ class ncclLLPrimitives {
     return LLGenericOp<0, 0, 1, 1, FuncMax<T>>(src, dst, nelem);
   }
 
+  __device__ void invsqrt(const T* src, T* dst, int nelem) {
+    return LLGenericOp<0, 0, 1, 1, FuncInvSqrt<T>>(src, dst, nelem);
+  }
+
   __device__ __forceinline__ ~ncclLLPrimitives() {
     // Save steps for the next operation
     saveRecvSync();

--- a/src/collectives/device/prims_ll128.h
+++ b/src/collectives/device/prims_ll128.h
@@ -383,29 +383,9 @@ class ncclLL128Primitives {
     return GenericOp<1, 1, 1, 1>(src, dst, nelem);
   }
 
-  __device__ void add(const T* src, T* dst, int nelem) {
-    return GenericOp<0, 0, 1, 1, FuncSum<T>>(src, dst, nelem);
-  }
-
-  __device__ void sub(const T* src, T* dst, int nelem) {
-    return GenericOp<0, 0, 1, 1, FuncDiff<T>>(src, dst, nelem);
-  }
-
-  __device__ void mul(const T* src, T* dst, int nelem) {
-    return GenericOp<0, 0, 1, 1, FuncProd<T>>(src, dst, nelem);
-  }
-
-  // Note this method cannot be named "min" due to a name conflict
-  __device__ void minimum(const T* src, T* dst, int nelem) {
-    return GenericOp<0, 0, 1, 1, FuncMin<T>>(src, dst, nelem);
-  }
-
-  __device__ void maximum(const T* src, T* dst, int nelem) {
-    return GenericOp<0, 0, 1, 1, FuncMax<T>>(src, dst, nelem);
-  }
-
-  __device__ void invsqrt(const T* src, T* dst, int nelem) {
-    return GenericOp<0, 0, 1, 1, FuncInvSqrt<T>>(src, dst, nelem);
+  template <class BinaryOp>
+  __device__ void binaryOp(const T* src, T* dst, int nelem) {
+    return GenericOp<0, 0, 1, 1, BinaryOp>(src, dst, nelem);
   }
 
   __device__ __forceinline__ ~ncclLL128Primitives() {

--- a/src/collectives/device/prims_ll128.h
+++ b/src/collectives/device/prims_ll128.h
@@ -404,6 +404,10 @@ class ncclLL128Primitives {
     return GenericOp<0, 0, 1, 1, FuncMax<T>>(src, dst, nelem);
   }
 
+  __device__ void invsqrt(const T* src, T* dst, int nelem) {
+    return GenericOp<0, 0, 1, 1, FuncInvSqrt<T>>(src, dst, nelem);
+  }
+
   __device__ __forceinline__ ~ncclLL128Primitives() {
     // Save steps for the next operation
     saveRecvSync();

--- a/src/collectives/device/prims_ll128.h
+++ b/src/collectives/device/prims_ll128.h
@@ -383,6 +383,10 @@ class ncclLL128Primitives {
     return GenericOp<1, 1, 1, 1>(src, dst, nelem);
   }
 
+  __device__ void binaryOp(const T* src, T* dst, int nelem) {
+    return GenericOp<0, 0, 1, 1>(src, dst, nelem);
+  }
+
   __device__ __forceinline__ ~ncclLL128Primitives() {
     // Save steps for the next operation
     saveRecvSync();

--- a/src/collectives/device/reduce_kernel.h
+++ b/src/collectives/device/reduce_kernel.h
@@ -254,6 +254,21 @@ struct FuncSum<half> {
 };
 
 template<>
+struct FuncDiff<half> {
+  __device__ half2 operator()(const half2 x, const half2 y) const {
+    float2 fx, fy, fr;
+    fx = __half22float2(x);
+    fy = __half22float2(y);
+    fr.x = fx.x - fy.x;
+    fr.y = fx.y - fy.y;
+    return __float22half2_rn(fr);
+  }
+  __device__ half operator()(const half x, const half y) const {
+    return __float2half( __half2float(x) - __half2float(y) );
+  }
+};
+
+template<>
 struct FuncProd<half> {
   __device__ half2 operator()(const half2 x, const half2 y) const {
 #if __CUDA_ARCH__ >= 530 && __CUDA_ARCH__ != 610
@@ -313,4 +328,19 @@ struct FuncMin<half> {
     return __float2half(fm);
   }
 };
+
+template<>
+struct FuncRSqrt<half> {
+  __device__ half2 operator()(const half2 x, const half2 y) const {
+    float2 fx, fr;
+    fx = __half22float2(x);
+    fr.x = 1.0f / sqrt(fx.x);
+    fr.y = 1.0f / sqrt(fx.y);
+    return __float22half2_rn(fr);
+  }
+  __device__ half operator()(const half x, const half y) const {
+    return __float2half( 1.0f / sqrt(__half2float(x)) );
+  }
+};
+
 #endif // REDUCE_KERNEL_H_

--- a/src/collectives/device/reduce_kernel.h
+++ b/src/collectives/device/reduce_kernel.h
@@ -26,6 +26,13 @@ struct FuncSum {
 };
 
 template<typename T>
+struct FuncDiff {
+  __device__ T operator()(const T x, const T y) const {
+    return x - y;
+  }
+};
+
+template<typename T>
 struct FuncProd {
   __device__ T operator()(const T x, const T y) const {
     return x * y;

--- a/src/collectives/device/reduce_kernel.h
+++ b/src/collectives/device/reduce_kernel.h
@@ -54,7 +54,7 @@ struct FuncMin {
 };
 
 template<typename T>
-struct FuncInvSqrt {
+struct FuncRSqrt {
   __device__ T operator()(const T x, const T) const {
     return 1.0f / sqrt((float)x);
   }

--- a/src/collectives/device/reduce_kernel.h
+++ b/src/collectives/device/reduce_kernel.h
@@ -53,6 +53,13 @@ struct FuncMin {
   }
 };
 
+template<typename T>
+struct FuncInvSqrt {
+  __device__ T operator()(const T x, const T) const {
+    return 1.0f / sqrt((float)x);
+  }
+};
+
 #define MASK0 0x00ff00ff
 #define MASK1 0xff00ff00
 static __device__ uint32_t addChar4(const uint32_t x, const uint32_t y) {

--- a/src/collectives/device/sccl_interpreter.h
+++ b/src/collectives/device/sccl_interpreter.h
@@ -87,8 +87,20 @@ class scclFunction {
               case SCCL_RECV_REDUCE_COPY:
                 prims.recvReduceCopy(srcPointer + srcoffset, dstPointer + dstoffset, thisCount);
                 break;
-              case SCCL_BINARY_OP:
-                prims.binaryOp(srcPointer + srcoffset, dstPointer + dstoffset, thisCount);
+              case SCCL_ADD:
+                prims.add(srcPointer + srcoffset, dstPointer + dstoffset, thisCount);
+                break;
+              case SCCL_SUB:
+                prims.sub(srcPointer + srcoffset, dstPointer + dstoffset, thisCount);
+                break;
+              case SCCL_MUL:
+                prims.mul(srcPointer + srcoffset, dstPointer + dstoffset, thisCount);
+                break;
+              case SCCL_MIN:
+                prims.minimum(srcPointer + srcoffset, dstPointer + dstoffset, thisCount);
+                break;
+              case SCCL_MAX:
+                prims.maximum(srcPointer + srcoffset, dstPointer + dstoffset, thisCount);
                 break;
               case SCCL_NO_OP:
                 break;
@@ -149,8 +161,24 @@ struct SimpleWrapper {
     prims.recvReduceCopy(srcChunkPointer, dstChunkPointer, nelem*count);
   }
 
-  __device__ void binaryOp(T * srcChunkPointer, T * dstChunkPointer, int count) {
-    prims.binaryOp(srcChunkPointer, dstChunkPointer, nelem*count);
+  __device__ void add(T * srcChunkPointer, T * dstChunkPointer, int count) {
+    prims.add(srcChunkPointer, dstChunkPointer, nelem*count);
+  }
+
+  __device__ void sub(T * srcChunkPointer, T * dstChunkPointer, int count) {
+    prims.sub(srcChunkPointer, dstChunkPointer, nelem*count);
+  }
+
+  __device__ void mul(T * srcChunkPointer, T * dstChunkPointer, int count) {
+    prims.mul(srcChunkPointer, dstChunkPointer, nelem*count);
+  }
+
+  __device__ void minimum(T * srcChunkPointer, T * dstChunkPointer, int count) {
+    prims.minimum(srcChunkPointer, dstChunkPointer, nelem*count);
+  }
+
+  __device__ void maximum(T * srcChunkPointer, T * dstChunkPointer, int count) {
+    prims.maximum(srcChunkPointer, dstChunkPointer, nelem*count);
   }
 };
 
@@ -200,9 +228,25 @@ struct LL128Wrapper {
     prims.recvReduceCopy(srcChunkPointer, dstChunkPointer, nelem*count);
   }  
 
-  __device__ void binaryOp(T * srcChunkPointer, T * dstChunkPointer, int count) {
-    prims.binaryOp(srcChunkPointer, dstChunkPointer, nelem*count);
-  }  
+  __device__ void add(T * srcChunkPointer, T * dstChunkPointer, int count) {
+    prims.add(srcChunkPointer, dstChunkPointer, nelem*count);
+  }
+
+  __device__ void sub(T * srcChunkPointer, T * dstChunkPointer, int count) {
+    prims.sub(srcChunkPointer, dstChunkPointer, nelem*count);
+  }
+
+  __device__ void mul(T * srcChunkPointer, T * dstChunkPointer, int count) {
+    prims.mul(srcChunkPointer, dstChunkPointer, nelem*count);
+  }
+
+  __device__ void minimum(T * srcChunkPointer, T * dstChunkPointer, int count) {
+    prims.minimum(srcChunkPointer, dstChunkPointer, nelem*count);
+  }
+
+  __device__ void maximum(T * srcChunkPointer, T * dstChunkPointer, int count) {
+    prims.maximum(srcChunkPointer, dstChunkPointer, nelem*count);
+  }
 };
 
 template<class FUNC, typename T, int UNROLL>
@@ -247,9 +291,25 @@ struct LLWrapper {
     prims.recvReduceCopy(srcChunkPointer, dstChunkPointer, nelem*count);
   }  
 
-  __device__ void binaryOp(T * srcChunkPointer, T * dstChunkPointer, int count) {
-    prims.binaryOp(srcChunkPointer, dstChunkPointer, nelem*count);
-  }  
+  __device__ void add(T * srcChunkPointer, T * dstChunkPointer, int count) {
+    prims.add(srcChunkPointer, dstChunkPointer, nelem*count);
+  }
+
+  __device__ void sub(T * srcChunkPointer, T * dstChunkPointer, int count) {
+    prims.sub(srcChunkPointer, dstChunkPointer, nelem*count);
+  }
+
+  __device__ void mul(T * srcChunkPointer, T * dstChunkPointer, int count) {
+    prims.mul(srcChunkPointer, dstChunkPointer, nelem*count);
+  }
+
+  __device__ void minimum(T * srcChunkPointer, T * dstChunkPointer, int count) {
+    prims.minimum(srcChunkPointer, dstChunkPointer, nelem*count);
+  }
+
+  __device__ void maximum(T * srcChunkPointer, T * dstChunkPointer, int count) {
+    prims.maximum(srcChunkPointer, dstChunkPointer, nelem*count);
+  }
 };
 
 template<class FUNC, typename T, int UNROLL>

--- a/src/collectives/device/sccl_interpreter.h
+++ b/src/collectives/device/sccl_interpreter.h
@@ -102,6 +102,9 @@ class scclFunction {
               case SCCL_MAX:
                 prims.maximum(srcPointer + srcoffset, dstPointer + dstoffset, thisCount);
                 break;
+              case SCCL_ISQRT:
+                prims.invsqrt(srcPointer + srcoffset, dstPointer + dstoffset, thisCount);
+                break;
               case SCCL_NO_OP:
                 break;
               default:
@@ -180,6 +183,10 @@ struct SimpleWrapper {
   __device__ void maximum(T * srcChunkPointer, T * dstChunkPointer, int count) {
     prims.maximum(srcChunkPointer, dstChunkPointer, nelem*count);
   }
+
+  __device__ void invsqrt(T * srcChunkPointer, T * dstChunkPointer, int count) {
+    prims.invsqrt(srcChunkPointer, dstChunkPointer, nelem*count);
+  }
 };
 
 template<class FUNC, typename T, int UNROLL>
@@ -247,6 +254,10 @@ struct LL128Wrapper {
   __device__ void maximum(T * srcChunkPointer, T * dstChunkPointer, int count) {
     prims.maximum(srcChunkPointer, dstChunkPointer, nelem*count);
   }
+
+  __device__ void invsqrt(T * srcChunkPointer, T * dstChunkPointer, int count) {
+    prims.invsqrt(srcChunkPointer, dstChunkPointer, nelem*count);
+  }
 };
 
 template<class FUNC, typename T, int UNROLL>
@@ -309,6 +320,10 @@ struct LLWrapper {
 
   __device__ void maximum(T * srcChunkPointer, T * dstChunkPointer, int count) {
     prims.maximum(srcChunkPointer, dstChunkPointer, nelem*count);
+  }
+
+  __device__ void invsqrt(T * srcChunkPointer, T * dstChunkPointer, int count) {
+    prims.invsqrt(srcChunkPointer, dstChunkPointer, nelem*count);
   }
 };
 

--- a/src/collectives/device/sccl_interpreter.h
+++ b/src/collectives/device/sccl_interpreter.h
@@ -34,7 +34,7 @@ class scclFunction {
       int recvPeer = scclTB->recvpeer;
       int sendPeer = scclTB->sendpeer;
 
-      //if (tid == 0) printf("tid %d, bid %d, channelId %d, input %p, output %p, scratch %p, arg[0] %p, arg[1] %p, recv %d, send %d\n", tid, bid, channelId, thisInput, thisOutput, thisScratch, args->argbuffs[0], args->argbuffs[0], recvPeer, sendPeer);
+      if (tid == 0) printf("tid %d, bid %d, channelId %d, input %p, output %p, scratch %p, arg[0] %p, arg[1] %p, recv %d, send %d\n", tid, bid, channelId, thisInput, thisOutput, thisScratch, args->argbuffs[0], args->argbuffs[0], recvPeer, sendPeer);
 
       PRIMS_WRAPPER prims{args, tid, &recvPeer, &sendPeer, thisOutput, channel};
 
@@ -79,11 +79,11 @@ class scclFunction {
                      : (sccltran->src2buffer == SCCL_SCRATCH_BUFFER) ? thisScratch
                      : (T *)(args->argbuffs[sccltran->src2buffer - SCCL_ARG_BUFFERS_BEGIN]);
           int count = sccltran->count;
-          //if (tid == 0)
-          //  printf("SCCL iter %ld, step %d, op %d count %d src %p dst %p src2 %p\n",
-          //         iter, i,
-          //         sccltran->type, count,
-          //         srcPointer, dstPointer, src2Pointer);
+          if (tid == 0)
+            printf("SCCL iter %ld, step %d, op %d count %d src %p dst %p src2 %p\n",
+                   iter, i,
+                   sccltran->type, count,
+                   srcPointer, dstPointer, src2Pointer);
           for (int c = 0; c < count; c += scclMaxAllowedCount) {
             srcoffset = chunkOffset + (ssize_t) (sccltran->srcoffset+c) * sizePerScclChunk;
             dstoffset = chunkOffset + (ssize_t) (sccltran->dstoffset+c) * sizePerScclChunk;

--- a/src/collectives/device/sccl_interpreter.h
+++ b/src/collectives/device/sccl_interpreter.h
@@ -78,17 +78,18 @@ class scclFunction {
                      : (sccltran->src2buffer == SCCL_OUTPUT_BUFFER) ? thisOutput
                      : (sccltran->src2buffer == SCCL_SCRATCH_BUFFER) ? thisScratch
                      : (T *)(args->argbuffs[sccltran->src2buffer - SCCL_ARG_BUFFERS_BEGIN]);
-          int count = sccltran->count;
-          //if (tid == 0)
-          //  printf("SCCL iter %ld, step %d, op %d count %d src %p dst %p src2 %p\n",
-          //         iter, i,
-          //         sccltran->type, count,
-          //         srcPointer, dstPointer, src2Pointer);
+          const int count = sccltran->count;
           for (int c = 0; c < count; c += scclMaxAllowedCount) {
             srcoffset = chunkOffset + (ssize_t) (sccltran->srcoffset+c) * sizePerScclChunk;
             dstoffset = chunkOffset + (ssize_t) (sccltran->dstoffset+c) * sizePerScclChunk;
             src2offset = chunkOffset + (ssize_t) (sccltran->src2offset+c) * sizePerScclChunk;
-            int thisCount = min(scclMaxAllowedCount, count-c);
+            const int thisCount = min(scclMaxAllowedCount, count-c);
+            //if (tid == 0)
+            //  printf("SCCL iter %ld, step %d, op %d, count %d, thisCount %d, maxAllowedCount %d, "
+            //         "src %p dst %p src2 %p\n",
+            //         iter, i,
+            //         sccltran->type, count, thisCount, scclMaxAllowedCount,
+            //         srcPointer, dstPointer, src2Pointer);
             switch (sccltran->type) {
               case SCCL_SEND:
                 prims.send(srcPointer + srcoffset, dstoffset, thisCount);

--- a/src/collectives/device/sccl_interpreter.h
+++ b/src/collectives/device/sccl_interpreter.h
@@ -34,7 +34,7 @@ class scclFunction {
       int recvPeer = scclTB->recvpeer;
       int sendPeer = scclTB->sendpeer;
 
-      //printf("tid %d, bid %d, channelId %d, input %p, output %p, scratch %p, arg[0] %p, arg[1] %p, recv %d, send %d\n", tid, bid, channelId, thisInput, thisOutput, thisScratch, args->argbuffs[0], args->argbuffs[0], recvPeer, sendPeer);
+      //if (tid == 0) printf("tid %d, bid %d, channelId %d, input %p, output %p, scratch %p, arg[0] %p, arg[1] %p, recv %d, send %d\n", tid, bid, channelId, thisInput, thisOutput, thisScratch, args->argbuffs[0], args->argbuffs[0], recvPeer, sendPeer);
 
       PRIMS_WRAPPER prims{args, tid, &recvPeer, &sendPeer, thisOutput, channel};
 
@@ -79,9 +79,11 @@ class scclFunction {
                      : (sccltran->src2buffer == SCCL_SCRATCH_BUFFER) ? thisScratch
                      : (T *)(args->argbuffs[sccltran->src2buffer - SCCL_ARG_BUFFERS_BEGIN]);
           int count = sccltran->count;
-          //printf("SCCL iter %ld, step %d, op %d count %d src %p dst %p src2 %p\n",
-          //       iter, i,
-          //       sccltran->type, count, srcPointer, dstPointer, src2Pointer);
+          //if (tid == 0)
+          //  printf("SCCL iter %ld, step %d, op %d count %d src %p dst %p src2 %p\n",
+          //         iter, i,
+          //         sccltran->type, count,
+          //         srcPointer, dstPointer, src2Pointer);
           for (int c = 0; c < count; c += scclMaxAllowedCount) {
             srcoffset = chunkOffset + (ssize_t) (sccltran->srcoffset+c) * sizePerScclChunk;
             dstoffset = chunkOffset + (ssize_t) (sccltran->dstoffset+c) * sizePerScclChunk;

--- a/src/collectives/device/sccl_interpreter.h
+++ b/src/collectives/device/sccl_interpreter.h
@@ -128,8 +128,8 @@ class scclFunction {
                     srcPointer + srcoffset, src2Pointer + src2offset,
                     dstPointer + dstoffset, thisCount);
                 break;
-              case SCCL_ISQRT:
-                prims.template binaryOp<FuncInvSqrt<float>, float>(
+              case SCCL_RSQRT:
+                prims.template binaryOp<FuncRSqrt<float>, float>(
                     srcPointer + srcoffset, srcPointer + srcoffset,
                     dstPointer + dstoffset, thisCount);
                 break;

--- a/src/collectives/device/sccl_interpreter.h
+++ b/src/collectives/device/sccl_interpreter.h
@@ -87,6 +87,9 @@ class scclFunction {
               case SCCL_RECV_REDUCE_COPY:
                 prims.recvReduceCopy(srcPointer + srcoffset, dstPointer + dstoffset, thisCount);
                 break;
+              case SCCL_BINARY_OP:
+                prims.binaryOp(srcPointer + srcoffset, dstPointer + dstoffset, thisCount);
+                break;
               case SCCL_NO_OP:
                 break;
               default:
@@ -145,6 +148,10 @@ struct SimpleWrapper {
   __device__ void recvReduceCopy(T * srcChunkPointer, T * dstChunkPointer, int count) {
     prims.recvReduceCopy(srcChunkPointer, dstChunkPointer, nelem*count);
   }
+
+  __device__ void binaryOp(T * srcChunkPointer, T * dstChunkPointer, int count) {
+    prims.binaryOp(srcChunkPointer, dstChunkPointer, nelem*count);
+  }
 };
 
 template<class FUNC, typename T, int UNROLL>
@@ -192,6 +199,10 @@ struct LL128Wrapper {
   __device__ void recvReduceCopy(T * srcChunkPointer, T * dstChunkPointer, int count) {
     prims.recvReduceCopy(srcChunkPointer, dstChunkPointer, nelem*count);
   }  
+
+  __device__ void binaryOp(T * srcChunkPointer, T * dstChunkPointer, int count) {
+    prims.binaryOp(srcChunkPointer, dstChunkPointer, nelem*count);
+  }  
 };
 
 template<class FUNC, typename T, int UNROLL>
@@ -234,6 +245,10 @@ struct LLWrapper {
 
   __device__ void recvReduceCopy(T * srcChunkPointer, T * dstChunkPointer, int count) {
     prims.recvReduceCopy(srcChunkPointer, dstChunkPointer, nelem*count);
+  }  
+
+  __device__ void binaryOp(T * srcChunkPointer, T * dstChunkPointer, int count) {
+    prims.binaryOp(srcChunkPointer, dstChunkPointer, nelem*count);
   }  
 };
 

--- a/src/collectives/device/sccl_interpreter.h
+++ b/src/collectives/device/sccl_interpreter.h
@@ -34,7 +34,7 @@ class scclFunction {
       int recvPeer = scclTB->recvpeer;
       int sendPeer = scclTB->sendpeer;
 
-      if (tid == 0) printf("tid %d, bid %d, channelId %d, input %p, output %p, scratch %p, arg[0] %p, arg[1] %p, recv %d, send %d\n", tid, bid, channelId, thisInput, thisOutput, thisScratch, args->argbuffs[0], args->argbuffs[0], recvPeer, sendPeer);
+      //if (tid == 0) printf("tid %d, bid %d, channelId %d, input %p, output %p, scratch %p, arg[0] %p, arg[1] %p, recv %d, send %d\n", tid, bid, channelId, thisInput, thisOutput, thisScratch, args->argbuffs[0], args->argbuffs[0], recvPeer, sendPeer);
 
       PRIMS_WRAPPER prims{args, tid, &recvPeer, &sendPeer, thisOutput, channel};
 
@@ -79,11 +79,11 @@ class scclFunction {
                      : (sccltran->src2buffer == SCCL_SCRATCH_BUFFER) ? thisScratch
                      : (T *)(args->argbuffs[sccltran->src2buffer - SCCL_ARG_BUFFERS_BEGIN]);
           int count = sccltran->count;
-          if (tid == 0)
-            printf("SCCL iter %ld, step %d, op %d count %d src %p dst %p src2 %p\n",
-                   iter, i,
-                   sccltran->type, count,
-                   srcPointer, dstPointer, src2Pointer);
+          //if (tid == 0)
+          //  printf("SCCL iter %ld, step %d, op %d count %d src %p dst %p src2 %p\n",
+          //         iter, i,
+          //         sccltran->type, count,
+          //         srcPointer, dstPointer, src2Pointer);
           for (int c = 0; c < count; c += scclMaxAllowedCount) {
             srcoffset = chunkOffset + (ssize_t) (sccltran->srcoffset+c) * sizePerScclChunk;
             dstoffset = chunkOffset + (ssize_t) (sccltran->dstoffset+c) * sizePerScclChunk;

--- a/src/collectives/device/sccl_interpreter.h
+++ b/src/collectives/device/sccl_interpreter.h
@@ -107,32 +107,32 @@ class scclFunction {
                 prims.recvReduceCopy(srcPointer + srcoffset, dstPointer + dstoffset, thisCount);
                 break;
               case SCCL_ADD:
-                prims.template binaryOp<FuncSum<float>, float>(
+                prims.template binaryOp<FuncSum<T>, T>(
                     srcPointer + srcoffset, src2Pointer + src2offset,
                     dstPointer + dstoffset, thisCount);
                 break;
               case SCCL_SUB:
-                prims.template binaryOp<FuncDiff<float>, float>(
+                prims.template binaryOp<FuncDiff<T>, T>(
                     srcPointer + srcoffset, src2Pointer + src2offset,
                     dstPointer + dstoffset, thisCount);
                 break;
               case SCCL_MUL:
-                prims.template binaryOp<FuncProd<float>, float>(
+                prims.template binaryOp<FuncProd<T>, T>(
                     srcPointer + srcoffset, src2Pointer + src2offset,
                     dstPointer + dstoffset, thisCount);
                 break;
               case SCCL_MIN:
-                prims.template binaryOp<FuncMin<float>, float>(
+                prims.template binaryOp<FuncMin<T>, T>(
                     srcPointer + srcoffset, src2Pointer + src2offset,
                     dstPointer + dstoffset, thisCount);
                 break;
               case SCCL_MAX:
-                prims.template binaryOp<FuncMax<float>, float>(
+                prims.template binaryOp<FuncMax<T>, T>(
                     srcPointer + srcoffset, src2Pointer + src2offset,
                     dstPointer + dstoffset, thisCount);
                 break;
               case SCCL_RSQRT:
-                prims.template binaryOp<FuncRSqrt<float>, float>(
+                prims.template binaryOp<FuncRSqrt<T>, T>(
                     srcPointer + srcoffset, srcPointer + srcoffset,
                     dstPointer + dstoffset, thisCount);
                 break;

--- a/src/collectives/device/sccl_interpreter.h
+++ b/src/collectives/device/sccl_interpreter.h
@@ -96,22 +96,22 @@ class scclFunction {
                 prims.recvReduceCopy(srcPointer + srcoffset, dstPointer + dstoffset, thisCount);
                 break;
               case SCCL_ADD:
-                prims.add(srcPointer + srcoffset, dstPointer + dstoffset, thisCount);
+                prims.template binaryOp<FuncSum<T>>(srcPointer + srcoffset, dstPointer + dstoffset, thisCount);
                 break;
               case SCCL_SUB:
-                prims.sub(srcPointer + srcoffset, dstPointer + dstoffset, thisCount);
+                prims.template binaryOp<FuncDiff<T>>(srcPointer + srcoffset, dstPointer + dstoffset, thisCount);
                 break;
               case SCCL_MUL:
-                prims.mul(srcPointer + srcoffset, dstPointer + dstoffset, thisCount);
+                prims.template binaryOp<FuncProd<T>>(srcPointer + srcoffset, dstPointer + dstoffset, thisCount);
                 break;
               case SCCL_MIN:
-                prims.minimum(srcPointer + srcoffset, dstPointer + dstoffset, thisCount);
+                prims.template binaryOp<FuncMin<T>>(srcPointer + srcoffset, dstPointer + dstoffset, thisCount);
                 break;
               case SCCL_MAX:
-                prims.maximum(srcPointer + srcoffset, dstPointer + dstoffset, thisCount);
+                prims.template binaryOp<FuncMax<T>>(srcPointer + srcoffset, dstPointer + dstoffset, thisCount);
                 break;
               case SCCL_ISQRT:
-                prims.invsqrt(srcPointer + srcoffset, dstPointer + dstoffset, thisCount);
+                prims.template binaryOp<FuncInvSqrt<T>>(srcPointer + srcoffset, dstPointer + dstoffset, thisCount);
                 break;
               case SCCL_NO_OP:
                 break;
@@ -172,28 +172,9 @@ struct SimpleWrapper {
     prims.recvReduceCopy(srcChunkPointer, dstChunkPointer, nelem*count);
   }
 
-  __device__ void add(T * srcChunkPointer, T * dstChunkPointer, int count) {
-    prims.add(srcChunkPointer, dstChunkPointer, nelem*count);
-  }
-
-  __device__ void sub(T * srcChunkPointer, T * dstChunkPointer, int count) {
-    prims.sub(srcChunkPointer, dstChunkPointer, nelem*count);
-  }
-
-  __device__ void mul(T * srcChunkPointer, T * dstChunkPointer, int count) {
-    prims.mul(srcChunkPointer, dstChunkPointer, nelem*count);
-  }
-
-  __device__ void minimum(T * srcChunkPointer, T * dstChunkPointer, int count) {
-    prims.minimum(srcChunkPointer, dstChunkPointer, nelem*count);
-  }
-
-  __device__ void maximum(T * srcChunkPointer, T * dstChunkPointer, int count) {
-    prims.maximum(srcChunkPointer, dstChunkPointer, nelem*count);
-  }
-
-  __device__ void invsqrt(T * srcChunkPointer, T * dstChunkPointer, int count) {
-    prims.invsqrt(srcChunkPointer, dstChunkPointer, nelem*count);
+  template <class BinaryOp>
+  __device__ void binaryOp(T * srcChunkPointer, T * dstChunkPointer, int count) {
+    prims.template binaryOp<BinaryOp>(srcChunkPointer, dstChunkPointer, nelem*count);
   }
 };
 
@@ -243,28 +224,9 @@ struct LL128Wrapper {
     prims.recvReduceCopy(srcChunkPointer, dstChunkPointer, nelem*count);
   }  
 
-  __device__ void add(T * srcChunkPointer, T * dstChunkPointer, int count) {
-    prims.add(srcChunkPointer, dstChunkPointer, nelem*count);
-  }
-
-  __device__ void sub(T * srcChunkPointer, T * dstChunkPointer, int count) {
-    prims.sub(srcChunkPointer, dstChunkPointer, nelem*count);
-  }
-
-  __device__ void mul(T * srcChunkPointer, T * dstChunkPointer, int count) {
-    prims.mul(srcChunkPointer, dstChunkPointer, nelem*count);
-  }
-
-  __device__ void minimum(T * srcChunkPointer, T * dstChunkPointer, int count) {
-    prims.minimum(srcChunkPointer, dstChunkPointer, nelem*count);
-  }
-
-  __device__ void maximum(T * srcChunkPointer, T * dstChunkPointer, int count) {
-    prims.maximum(srcChunkPointer, dstChunkPointer, nelem*count);
-  }
-
-  __device__ void invsqrt(T * srcChunkPointer, T * dstChunkPointer, int count) {
-    prims.invsqrt(srcChunkPointer, dstChunkPointer, nelem*count);
+  template <class BinaryOp>
+  __device__ void binaryOp(T * srcChunkPointer, T * dstChunkPointer, int count) {
+    prims.template binaryOp<BinaryOp>(srcChunkPointer, dstChunkPointer, nelem*count);
   }
 };
 
@@ -310,28 +272,9 @@ struct LLWrapper {
     prims.recvReduceCopy(srcChunkPointer, dstChunkPointer, nelem*count);
   }  
 
-  __device__ void add(T * srcChunkPointer, T * dstChunkPointer, int count) {
-    prims.add(srcChunkPointer, dstChunkPointer, nelem*count);
-  }
-
-  __device__ void sub(T * srcChunkPointer, T * dstChunkPointer, int count) {
-    prims.sub(srcChunkPointer, dstChunkPointer, nelem*count);
-  }
-
-  __device__ void mul(T * srcChunkPointer, T * dstChunkPointer, int count) {
-    prims.mul(srcChunkPointer, dstChunkPointer, nelem*count);
-  }
-
-  __device__ void minimum(T * srcChunkPointer, T * dstChunkPointer, int count) {
-    prims.minimum(srcChunkPointer, dstChunkPointer, nelem*count);
-  }
-
-  __device__ void maximum(T * srcChunkPointer, T * dstChunkPointer, int count) {
-    prims.maximum(srcChunkPointer, dstChunkPointer, nelem*count);
-  }
-
-  __device__ void invsqrt(T * srcChunkPointer, T * dstChunkPointer, int count) {
-    prims.invsqrt(srcChunkPointer, dstChunkPointer, nelem*count);
+  template <class BinaryOp>
+  __device__ void binaryOp(T * srcChunkPointer, T * dstChunkPointer, int count) {
+    prims.template binaryOp<BinaryOp>(srcChunkPointer, dstChunkPointer, nelem*count);
   }
 };
 

--- a/src/enqueue.cc
+++ b/src/enqueue.cc
@@ -433,6 +433,7 @@ static ncclResult_t computeColl(struct ncclInfo* info /* input */, struct ncclWo
   work->sendbuff = info->sendbuff;
   work->recvbuff = info->recvbuff;
   work->scratchbuff = info->scratchbuff;
+  work->argbuffs = info->argbuffs;
   work->coll.root = info->root;
   work->coll.count = info->count;
   work->coll.nChannels = info->nChannels;

--- a/src/enqueue.cc
+++ b/src/enqueue.cc
@@ -62,7 +62,7 @@ static void* const ncclKerns[1+NCCL_NUM_FUNCTIONS*ncclNumOps*ncclNumTypes*NCCL_N
   NCCL_FUNCS2B(AllGather),
   NCCL_FUNCS2A(ReduceScatter),
   NCCL_FUNCS2A(AllReduce),
-  NCCL_FUNCS2B(AllToAll)
+  NCCL_FUNCS2A(AllToAll)
 };
 
 /*****************************************************************************/

--- a/src/enqueue.cc
+++ b/src/enqueue.cc
@@ -529,7 +529,9 @@ ncclResult_t ncclSaveKernel(struct ncclInfo* info) {
     return ncclSuccess;
   }
   // Alltoall needs a local copy and it has no allocated channel/threadblock. the corresponding chunk is transferred here
-  if (info->coll == ncclFuncAllToAll){
+  // [parasail/victor] We are abusing alltoall to invoke the SCCL interpreter,
+  // so no need for this chunk copy in SCCL interpreter use cases.
+  if (0 && info->coll == ncclFuncAllToAll){
     if (info->sendbuff == info->recvbuff){
       WARN("Alltoall needs separate receive and send buffers.");
       return ncclInvalidArgument;

--- a/src/graph/topo.cc
+++ b/src/graph/topo.cc
@@ -801,6 +801,8 @@ ncclResult_t scclGetAlgoFromXMLAndSetComm(struct ncclComm* comm) {
                 } else if (strcmp(type, "rrc") == 0) {
                   sccltran->type = SCCL_RECV_REDUCE_COPY;
                   hasRecv = 1;
+                } else if (strcmp(type, "binOp") == 0) {
+                  sccltran->type = SCCL_BINARY_OP;
                 } else if (strcmp(type, "nop") == 0) {
                   sccltran->type = SCCL_NO_OP;
                 } else {

--- a/src/graph/topo.cc
+++ b/src/graph/topo.cc
@@ -811,6 +811,8 @@ ncclResult_t scclGetAlgoFromXMLAndSetComm(struct ncclComm* comm) {
                   sccltran->type = SCCL_MIN;
                 } else if (strcmp(type, "max") == 0) {
                   sccltran->type = SCCL_MAX;
+                } else if (strcmp(type, "isqrt") == 0) {
+                  sccltran->type = SCCL_ISQRT;
                 } else if (strcmp(type, "nop") == 0) {
                   sccltran->type = SCCL_NO_OP;
                 } else {

--- a/src/graph/topo.cc
+++ b/src/graph/topo.cc
@@ -801,8 +801,16 @@ ncclResult_t scclGetAlgoFromXMLAndSetComm(struct ncclComm* comm) {
                 } else if (strcmp(type, "rrc") == 0) {
                   sccltran->type = SCCL_RECV_REDUCE_COPY;
                   hasRecv = 1;
-                } else if (strcmp(type, "binOp") == 0) {
-                  sccltran->type = SCCL_BINARY_OP;
+                } else if (strcmp(type, "add") == 0) {
+                  sccltran->type = SCCL_ADD;
+                } else if (strcmp(type, "sub") == 0) {
+                  sccltran->type = SCCL_SUB;
+                } else if (strcmp(type, "mul") == 0) {
+                  sccltran->type = SCCL_MUL;
+                } else if (strcmp(type, "min") == 0) {
+                  sccltran->type = SCCL_MIN;
+                } else if (strcmp(type, "max") == 0) {
+                  sccltran->type = SCCL_MAX;
                 } else if (strcmp(type, "nop") == 0) {
                   sccltran->type = SCCL_NO_OP;
                 } else {

--- a/src/graph/topo.cc
+++ b/src/graph/topo.cc
@@ -824,8 +824,8 @@ ncclResult_t scclGetAlgoFromXMLAndSetComm(struct ncclComm* comm) {
                   sccltran->type = SCCL_MIN;
                 } else if (strcmp(type, "max") == 0) {
                   sccltran->type = SCCL_MAX;
-                } else if (strcmp(type, "isqrt") == 0) {
-                  sccltran->type = SCCL_ISQRT;
+                } else if (strcmp(type, "rsqrt") == 0) {
+                  sccltran->type = SCCL_RSQRT;
                 } else if (strcmp(type, "nop") == 0) {
                   sccltran->type = SCCL_NO_OP;
                 } else {

--- a/src/graph/topo.cc
+++ b/src/graph/topo.cc
@@ -614,6 +614,8 @@ ncclResult_t scclGetBufferType(const char* str, uint8_t* output){
     *output = SCCL_OUTPUT_BUFFER;
   } else if (strcmp(str, "s") == 0) {
     *output = SCCL_SCRATCH_BUFFER;
+  } else if (str[0] == 'a') {
+    *output = SCCL_ARG_BUFFERS_BEGIN + std::atoi(str + 1);
   } else {
     WARN("type of buffer is not supported: %s", str);
     return ncclInvalidUsage;
@@ -637,6 +639,14 @@ ncclResult_t scclCheckBufferBounds(int bufferType, int offset, int nInputChunks,
       WARN("Incorrect offset set for scratch buffer: offset: %d maximum allowed: %d", offset, nScratchChunks);
       return ncclInvalidUsage;
     }
+  } else {
+    //TODO: Allow different number of chunks for separate arg buffers,
+    //      instead of tying them all to nScratchChunks
+    if (offset < -1 || offset >= nScratchChunks){
+      WARN("Incorrect offset set for arg buffer: offset: %d maximum allowed: %d", offset, nScratchChunks);
+      return ncclInvalidUsage;
+    }
+    return ncclSuccess;
   }
   return ncclSuccess;
 }

--- a/src/graph/topo.cc
+++ b/src/graph/topo.cc
@@ -728,10 +728,6 @@ ncclResult_t scclGetAlgoFromXMLAndSetComm(struct ncclComm* comm) {
             }
             struct scclThreadBlock* sTB = &scclAlgo->scclTB[bid];
             sTB->nsteps = 0;
-            if (recvpeer == -1 && sendpeer == -1){
-              WARN("No point in creating in threadblock %d on gpu %d", bid, id);
-              return ncclInvalidUsage;
-            }
             if (recvpeer < -1 || sendpeer < -1){
               WARN("Wrong recvpeer (%d) or sendpeer (%d) in threadblock %d on gpu %d", recvpeer, sendpeer, bid, id);
               return ncclInvalidUsage;

--- a/src/include/collectives.h
+++ b/src/include/collectives.h
@@ -58,7 +58,7 @@
   DECL2(AllGather, Sum) \
   DECL(ReduceScatter) \
   DECL(AllReduce) \
-  DECL2(AllToAll, Sum) \
+  DECL(AllToAll) \
   DECL5(SendRecv, RING, SIMPLE, Sum, int8_t) \
 
 DECL_ALL

--- a/src/include/devcomm.h
+++ b/src/include/devcomm.h
@@ -132,19 +132,23 @@ struct ncclRing {
 #define SCCL_RECV_REDUCE_SEND 3
 #define SCCL_RECV_REDUCE_COPY 4
 #define SCCL_NO_OP 5
-#define SCCL_ADD 6
-#define SCCL_SUB 7
-#define SCCL_MUL 8
-#define SCCL_MIN 9
-#define SCCL_MAX 10
+#define SCCL_BINARY_OP_BEGIN 6
+#define SCCL_ADD (SCCL_BINARY_OP_BEGIN + 0)
+#define SCCL_SUB (SCCL_BINARY_OP_BEGIN + 1)
+#define SCCL_MUL (SCCL_BINARY_OP_BEGIN + 2)
+#define SCCL_MIN (SCCL_BINARY_OP_BEGIN + 3)
+#define SCCL_MAX (SCCL_BINARY_OP_BEGIN + 4)
+#define SCCL_BINARY_OP_END (SCCL_MAX)
 #define SCCL_ISQRT 11
 
 // TODO: compress this by a lot!
 struct scclTransfer {
   int16_t srcoffset;
   int16_t dstoffset;
+  int16_t src2offset;
   uint8_t srcbuffer; // follow SCCL_THIS_INPUT/SCCL_THIS_OUTPUT macros
   uint8_t dstbuffer; // follow SCCL_THIS_INPUT/SCCL_THIS_OUTPUT macros
+  uint8_t src2buffer; // follow SCCL_THIS_INPUT/SCCL_THIS_OUTPUT macros
   int8_t dependentBid; // -1 if not dependent on any threadblock
   int16_t dependentStep;
   int8_t has_dependence;

--- a/src/include/devcomm.h
+++ b/src/include/devcomm.h
@@ -130,7 +130,11 @@ struct ncclRing {
 #define SCCL_RECV_REDUCE_SEND 3
 #define SCCL_RECV_REDUCE_COPY 4
 #define SCCL_NO_OP 5
-#define SCCL_BINARY_OP 6
+#define SCCL_ADD 6
+#define SCCL_SUB 7
+#define SCCL_MUL 8
+#define SCCL_MIN 9
+#define SCCL_MAX 10
 
 // TODO: compress this by a lot!
 struct scclTransfer {

--- a/src/include/devcomm.h
+++ b/src/include/devcomm.h
@@ -139,7 +139,7 @@ struct ncclRing {
 #define SCCL_MIN (SCCL_BINARY_OP_BEGIN + 3)
 #define SCCL_MAX (SCCL_BINARY_OP_BEGIN + 4)
 #define SCCL_BINARY_OP_END (SCCL_MAX)
-#define SCCL_ISQRT 11
+#define SCCL_RSQRT 11
 
 // TODO: compress this by a lot!
 struct scclTransfer {

--- a/src/include/devcomm.h
+++ b/src/include/devcomm.h
@@ -123,6 +123,8 @@ struct ncclRing {
 #define SCCL_INPUT_BUFFER 0
 #define SCCL_OUTPUT_BUFFER 1
 #define SCCL_SCRATCH_BUFFER 2
+#define SCCL_ARG_BUFFERS_BEGIN 3
+#define SCCL_ARG_BUFFERS_END (SCCL_ARG_BUFFERS_BEGIN + SCCL_NUM_ARG_BUFFS)
 
 #define SCCL_SEND 0
 #define SCCL_RECV 1
@@ -239,6 +241,7 @@ struct ncclWorkElem {
   const void * sendbuff;
   void * recvbuff;
   void * scratchbuff;
+  argBuffs_t argbuffs;
 
   // Op-specific fields.
   union {
@@ -261,7 +264,7 @@ struct ncclWorkElem {
 struct ncclWork {
   struct ncclWorkElem elems[NCCL_MAX_WORK_ELEMENTS];
 };
-static_assert(sizeof(struct ncclWorkElem) == (0x20*sizeof(int)), "ncclWorkElem must have a pow2 size");
+static_assert(sizeof(struct ncclWorkElem) == (0x40*sizeof(int)), "ncclWorkElem must have a pow2 size");
 
 struct ncclChannel {
   union {

--- a/src/include/devcomm.h
+++ b/src/include/devcomm.h
@@ -130,6 +130,7 @@ struct ncclRing {
 #define SCCL_RECV_REDUCE_SEND 3
 #define SCCL_RECV_REDUCE_COPY 4
 #define SCCL_NO_OP 5
+#define SCCL_BINARY_OP 6
 
 // TODO: compress this by a lot!
 struct scclTransfer {

--- a/src/include/devcomm.h
+++ b/src/include/devcomm.h
@@ -268,7 +268,7 @@ struct ncclWorkElem {
 struct ncclWork {
   struct ncclWorkElem elems[NCCL_MAX_WORK_ELEMENTS];
 };
-static_assert(sizeof(struct ncclWorkElem) == (0x40*sizeof(int)), "ncclWorkElem must have a pow2 size");
+static_assert(sizeof(struct ncclWorkElem) == (0x80*sizeof(int)), "ncclWorkElem must have a pow2 size");
 
 struct ncclChannel {
   union {

--- a/src/include/devcomm.h
+++ b/src/include/devcomm.h
@@ -135,6 +135,7 @@ struct ncclRing {
 #define SCCL_MUL 8
 #define SCCL_MIN 9
 #define SCCL_MAX 10
+#define SCCL_ISQRT 11
 
 // TODO: compress this by a lot!
 struct scclTransfer {

--- a/src/include/info.h
+++ b/src/include/info.h
@@ -56,6 +56,10 @@ struct ncclInfo {
   // SCCL scratch buffer is passed as an arg
   // this scratchBuffer can be accessed on the device. The management of this memory is on scclAlgorithm
   void* scratchbuff;
+
+  // SCCL additional args for pointers to buffers accessible on the device.
+  // The management of this memory is up to the user.
+  argBuffs_t argbuffs;
 };
 
 #endif

--- a/src/misc/argcheck.cc
+++ b/src/misc/argcheck.cc
@@ -45,12 +45,12 @@ ncclResult_t ArgsCheck(struct ncclInfo* info) {
   }
   // Type is OK, compute nbytes. Convert Allgather/Broadcast/P2P calls to chars.
   info->nBytes = info->count * ncclTypeSize(info->datatype);
-  if (info->coll == ncclFuncAllGather || info->coll == ncclFuncBroadcast || info->coll == ncclFuncAllToAll) {
+  if (info->coll == ncclFuncAllGather || info->coll == ncclFuncBroadcast) {
     info->count = info->nBytes;
     info->datatype = ncclInt8;
   }
   
-  if (info->coll == ncclFuncAllToAll || info->coll == ncclFuncAllGather || info->coll == ncclFuncReduceScatter) info->nBytes *= info->comm->nRanks; // count is per rank
+  if (info->coll == ncclFuncAllGather || info->coll == ncclFuncReduceScatter) info->nBytes *= info->comm->nRanks; // count is per rank
 
   if (info->op < 0 || info->op >= ncclNumOps) {
     WARN("%s : invalid reduction operation %d", info->opName, info->op);

--- a/src/nccl.h.in
+++ b/src/nccl.h.in
@@ -230,7 +230,7 @@ ncclResult_t pncclAllGather(const void* sendbuff, void* recvbuff, size_t sendcou
  *
  * In-place operations is not permitted.
  */
-#define SCCL_NUM_ARG_BUFFS 16
+#define SCCL_NUM_ARG_BUFFS 48
 struct argBuffs_t {
   void* argbuffs[SCCL_NUM_ARG_BUFFS];
 #ifdef __cplusplus

--- a/src/nccl.h.in
+++ b/src/nccl.h.in
@@ -230,7 +230,18 @@ ncclResult_t pncclAllGather(const void* sendbuff, void* recvbuff, size_t sendcou
  *
  * In-place operations is not permitted.
  */
-ncclResult_t  ncclAllToAll(const void* sendbuff, void* recvbuff, size_t sendcount,
+#define SCCL_NUM_ARG_BUFFS 16
+struct argBuffs_t {
+  void* argbuffs[SCCL_NUM_ARG_BUFFS];
+#ifdef __cplusplus
+#ifdef __CUDA_ARCH__
+  __device__
+#endif
+  void*& operator[](size_t index) { return argbuffs[index]; }
+#endif
+};
+typedef struct argBuffs_t argBuffs_t;
+ncclResult_t  ncclAllToAll(const void* sendbuff, void* recvbuff, argBuffs_t argbuffs, size_t sendcount,
     ncclDataType_t datatype, ncclComm_t comm, cudaStream_t stream);
 ncclResult_t pncclncclAllToAll(const void* sendbuff, void* recvbuff, size_t sendcount,
     ncclDataType_t datatype, ncclComm_t comm, cudaStream_t stream);


### PR DESCRIPTION
Also allow passing an array of 16 additional buffer pointers to `ncclAllToAll` so that
the interpreter instructions have access to more operands than just the input, output, and scratch buffers.
This is to enable expressing computation. This PR includes only elementwise operations on 32-bit floats;
we can imagine adding more instructions for other datatypes as well as other sorts of operations
to shuffle or reduce elements within one buffer.

Note: This initial verison is going to be very inefficient due to
the lack of fusing arithmetic together with other operations,
so every operation is going to have to stream operands from global memory.